### PR TITLE
Add methods to retrieve episode details in podcast playlist

### DIFF
--- a/tests/test_podcastplaylist.py
+++ b/tests/test_podcastplaylist.py
@@ -91,3 +91,34 @@ def test_convert_duration_to_string():
     playlist = PodcastPlaylist(name="Test Playlist", episodes=[])
     duration_string = playlist.convert_duration_to_string(5400)
     assert duration_string == "0 days, 01:30:00"
+
+def test_get_all_episode_details():
+    episode1 = PodcastEpisode(title="Episode 1", audio_url="https://example.com/episode1.mp3", duration=1800)
+    episode2 = PodcastEpisode(title="Episode 2", audio_url="https://example.com/episode2.mp3", duration=3600)
+    playlist = PodcastPlaylist(name="Test Playlist", episodes=[episode1, episode2])
+    details = playlist.get_all_episode_details()
+    assert len(details) == 2
+    assert details[0]["title"] == "Episode 1"
+    assert details[0]["duration"] == 1800
+    assert details[0]["audio_url"] == "https://example.com/episode1.mp3"
+    assert details[1]["title"] == "Episode 2"
+    assert details[1]["duration"] == 3600
+    assert details[1]["audio_url"] == "https://example.com/episode2.mp3"
+
+def test_get_first_episode_details():
+    episode1 = PodcastEpisode(title="Episode 1", audio_url="https://example.com/episode1.mp3", duration=1800)
+    episode2 = PodcastEpisode(title="Episode 2", audio_url="https://example.com/episode2.mp3", duration=3600)
+    playlist = PodcastPlaylist(name="Test Playlist", episodes=[episode1, episode2])
+    details = playlist.get_first_episode_details()
+    assert details["title"] == "Episode 1"
+    assert details["duration"] == 1800
+    assert details["audio_url"] == "https://example.com/episode1.mp3"
+
+def test_get_episode_details():
+    episode1 = PodcastEpisode(title="Episode 1", audio_url="https://example.com/episode1.mp3", duration=1800)
+    episode2 = PodcastEpisode(title="Episode 2", audio_url="https://example.com/episode2.mp3", duration=3600)
+    playlist = PodcastPlaylist(name="Test Playlist", episodes=[episode1, episode2])
+    details = playlist.get_episode_details(1)
+    assert details["title"] == "Episode 2"
+    assert details["duration"] == 3600
+    assert details["audio_url"] == "https://example.com/episode2.mp3"

--- a/tests/test_podcastplaylist.py
+++ b/tests/test_podcastplaylist.py
@@ -105,15 +105,6 @@ def test_get_all_episode_details():
     assert details[1]["duration"] == 3600
     assert details[1]["audio_url"] == "https://example.com/episode2.mp3"
 
-def test_get_first_episode_details():
-    episode1 = PodcastEpisode(title="Episode 1", audio_url="https://example.com/episode1.mp3", duration=1800)
-    episode2 = PodcastEpisode(title="Episode 2", audio_url="https://example.com/episode2.mp3", duration=3600)
-    playlist = PodcastPlaylist(name="Test Playlist", episodes=[episode1, episode2])
-    details = playlist.get_first_episode_details()
-    assert details["title"] == "Episode 1"
-    assert details["duration"] == 1800
-    assert details["audio_url"] == "https://example.com/episode1.mp3"
-
 def test_get_episode_details():
     episode1 = PodcastEpisode(title="Episode 1", audio_url="https://example.com/episode1.mp3", duration=1800)
     episode2 = PodcastEpisode(title="Episode 2", audio_url="https://example.com/episode2.mp3", duration=3600)

--- a/zpodcast/podcastplaylist.py
+++ b/zpodcast/podcastplaylist.py
@@ -77,16 +77,6 @@ class PodcastPlaylist:
             episode_details.append(details)
         return episode_details
 
-    def get_first_episode_details(self) -> Dict[str, str]:
-        if not self.episodes:
-            return {}
-        first_episode = self.episodes[0]
-        return {
-            "title": first_episode.title,
-            "duration": first_episode.duration,
-            "audio_url": first_episode.audio_url
-        }
-
     def get_episode_details(self, index: int) -> Dict[str, str]:
         if index < 0 or index >= len(self.episodes):
             return {}

--- a/zpodcast/podcastplaylist.py
+++ b/zpodcast/podcastplaylist.py
@@ -65,3 +65,34 @@ class PodcastPlaylist:
         if current_index >= 0 and current_index < len(self.episodes) and new_index >= 0 and new_index < len(self.episodes):
             episode = self.episodes.pop(current_index)
             self.episodes.insert(new_index, episode)
+
+    def get_all_episode_details(self) -> List[Dict[str, str]]:
+        episode_details = []
+        for episode in self.episodes:
+            details = {
+                "title": episode.title,
+                "duration": episode.duration,
+                "audio_url": episode.audio_url
+            }
+            episode_details.append(details)
+        return episode_details
+
+    def get_first_episode_details(self) -> Dict[str, str]:
+        if not self.episodes:
+            return {}
+        first_episode = self.episodes[0]
+        return {
+            "title": first_episode.title,
+            "duration": first_episode.duration,
+            "audio_url": first_episode.audio_url
+        }
+
+    def get_episode_details(self, index: int) -> Dict[str, str]:
+        if index < 0 or index >= len(self.episodes):
+            return {}
+        episode = self.episodes[index]
+        return {
+            "title": episode.title,
+            "duration": episode.duration,
+            "audio_url": episode.audio_url
+        }


### PR DESCRIPTION
Related to #23

provide the ability to get all episode details
provide the aiblity to get the first episode's details
provide the ability to get a specific episode's details

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ezigus/zpodcast/pull/24?shareId=08ad762f-d7b5-488c-9fd7-7d319b99b533).